### PR TITLE
docs: document admin password recovery and fix misleading admin123 re…

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Once you see "Application startup complete", open http://localhost:3000 and logi
 3. Login with username `admin` and the password from logs
 4. Create additional users in Admin panel
 
+> **Note**: The admin password is randomly generated at first startup for security.
+> It is **not** a fixed default like `admin123`. If you don't see it in the logs, see [Password Recovery](#admin-password-lost--not-in-logs) below.
+
 ### Upload Documents
 
 1. Login as Super User or Admin
@@ -217,6 +220,30 @@ docker compose logs backend -f
 ```
 
 Look for "Application startup complete" message.
+
+### Admin password lost / not in logs
+
+The admin password is randomly generated on first startup. If the logs have been cleared and you can't find it:
+
+**Option A**: Set a custom password and recreate the admin user:
+```bash
+# 1. Add to your .env file
+echo "ADMIN_DEFAULT_PASSWORD=your-secure-password" >> .env
+
+# 2. Delete the user database to force recreation
+docker compose exec backend rm /app/data/rag_users.db
+
+# 3. Restart the backend
+docker compose restart backend
+```
+
+**Option B**: Set `ADMIN_DEFAULT_PASSWORD` in `.env` before first startup to avoid random passwords entirely:
+```env
+# In .env - the admin account will use this password
+ADMIN_DEFAULT_PASSWORD=your-secure-password
+```
+
+> **Tip**: If you prefer a known password, set `ADMIN_DEFAULT_PASSWORD` in `.env` **before** first startup. Otherwise, the system generates a secure random password shown only once in the logs.
 
 ### Can't login / Frontend not loading
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,13 @@ When deploying RAG Enterprise, please follow these security guidelines:
   ```bash
   openssl rand -hex 32
   ```
-- **Change the default admin password** immediately after first login
+- **Admin password**: The initial admin password is randomly generated on first startup and shown in the backend logs. Retrieve it with:
+  ```bash
+  docker compose logs backend | grep "Password:"
+  ```
+- **Custom admin password**: You can set `ADMIN_DEFAULT_PASSWORD` in `.env` before first startup to use a known password instead of a random one
+- **Password recovery**: If logs are cleared and the password is lost, delete the user database and restart the backend (see [README Troubleshooting](README.md#admin-password-lost--not-in-logs))
+- **Change the admin password** immediately after first login
 - Use strong passwords for all user accounts
 
 ### 2. Network Security

--- a/rag-enterprise-structure/backend/app.py
+++ b/rag-enterprise-structure/backend/app.py
@@ -366,7 +366,8 @@ async def login(request: LoginRequest):
     User login - returns JWT token
 
     Default credentials:
-    - Admin: username=admin, password=admin123
+    - Admin: username=admin, password=<from logs or ADMIN_DEFAULT_PASSWORD env var>
+    - Get password: docker compose logs backend | grep "Password:"
     """
     user = db.authenticate_user(request.username, request.password)
 


### PR DESCRIPTION
…ference

- Fix outdated docstring in app.py that incorrectly stated default password as admin123
- Add "Admin password lost / not in logs" troubleshooting section to README.md
- Document ADMIN_DEFAULT_PASSWORD env variable and password reset procedure
- Expand authentication section in SECURITY.md with recovery instructions

https://claude.ai/code/session_01D5tQEZFMCcnvWYaCSpk8J8

## Description
Brief description of changes.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## How Has This Been Tested?
Describe the tests you ran.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged

## Screenshots (if applicable)
Add screenshots to help explain your changes.
