### PR TITLE
docs: add CHANGELOG.md, continuing the one from the Python line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,251 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+> **On the version numbers.** `1.0.0` to `1.2.1` are the Python stack,
+> preserved on the [`python-legacy`](../../tree/python-legacy) branch and no
+> longer developed. `0.1.x` is the Rust rewrite that replaced it: a new codebase,
+> which restarts the numbering at `0.1` because its storage layout and HTTP
+> surface are not settled yet. So the newer line carries the *lower* number —
+> see [Upgrading from 1.x](README.md#upgrading-from-1x).
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.1.26] - 2026-08-13
+
+### Changed
+
+- **The first run downloads 5 GB less** — `qwen3-8b` was pinned in
+  `manifest.toml` but referenced nowhere in the code, left over from a pipeline
+  this engine does not have. The first run goes from ~17.3 GB to ~12.3 GB. Every
+  component is still verified against a pinned sha256 before use. An existing
+  installation can delete `models/qwen3-8b/` to reclaim the space.
+- `EULLM__MODEL` now defaults to `qwen3-14b` and is no longer required. Starting
+  without it used to fail, for a setting the default configuration then ignores:
+  when the engine launches eullm itself it passes the GGUF path from the
+  manifest. It still applies if you run eullm separately and point the engine at
+  it. `AUTH__JWT_SECRET` is now the only setting with no default.
+- Remaining Italian text translated to English: the 503 returned while a document
+  is being ingested, the errors reported when the first run cannot download or
+  verify a component, and the stage labels of the `--bench` report.
+- README: documents what actually changed between the `1.x` Python stack and
+  this one, and states that the two cannot run side by side — they contend for
+  ports 8000, 6333 and 11434, so the Compose stack must be stopped first. The
+  `1.x` volumes are left in place, so going back remains possible.
+
+### Fixed
+
+- `Cargo.toml` declared `MIT OR Apache-2.0`; this project is Apache-2.0, as
+  `LICENSE` has always said.
+- The README still advertised a 17 GB first-run download after the manifest had
+  changed, and still listed `EULLM__MODEL` as required after it had been given a
+  default.
+
+### Removed
+
+- The `license/` module — dead code (`check_page_limit` was never called) that
+  described a commercial gating model not implemented here, and pulled in
+  `ed25519-dalek` for nothing.
+- Source comments referencing files and internal documents absent from this
+  repository, some of which described unreleased plans. Three stale `TODO`
+  markers on code that has been complete and working for a long time.
+
+### Notes
+
+No changes to retrieval, ingestion, chunking, embeddings or the HTTP API.
+Upgrading is a matter of replacing the binary; data and Qdrant collections are
+untouched.
+
+---
+
+## [0.1.25] - 2026-08-13
+
+First public release of the Rust rewrite. The system is now a **single binary**
+with no Docker, no Compose and no Java: on first run it downloads and
+sha256-verifies everything it needs — vector database, inference engine, models,
+OCR data — and supervises those processes itself. After that it needs no network
+at all.
+
+### Added
+
+- Single self-contained binary for Linux x86\_64 and arm64, with and without
+  CUDA, each published as a release tarball.
+- Component bootstrap driven by `manifest.toml`: every download is pinned by
+  sha256 and size, and a mismatch aborts the run. Platform variants are selected
+  at runtime, including a CIX P1 build of the inference engine gated on actual
+  CPU feature detection rather than on the SoC name.
+- Embeddings in-process via [Candle](https://github.com/huggingface/candle)
+  (BAAI/bge-m3, 1024 dimensions), on GPU or CPU, with
+  `EMBEDDINGS__REQUIRE_GPU` to refuse to start rather than silently degrade to a
+  much slower CPU path.
+- LLM inference through [eullm](https://github.com/eullm/eullm) as a supervised
+  subprocess, with VRAM handed back and forth around ingestion.
+- Document ingestion for PDF (including scanned pages via OCR), DOCX, XLSX, HTML,
+  TXT, Markdown and CSV. Scanned pages are detected automatically and passed
+  through Tesseract in Italian and English.
+- JWT authentication with three roles — user, super user, admin.
+- Streaming answers over SSE, with conversation history carried into follow-ups.
+- Scheduled backups of the SQLite database and the Qdrant collection together, so
+  a restore brings back a consistent pair.
+- `--bench` writes a Markdown report timing each stage of ingestion and inference
+  on your own hardware and document; `--bench-live` records a whole session
+  instead and reports on shutdown.
+
+### Changed
+
+- Apache-2.0, with a full third-party inventory in
+  [THIRD\_PARTY\_LICENSES.md](THIRD_PARTY_LICENSES.md).
+- The Python stack is preserved unchanged on
+  [`python-legacy`](../../tree/python-legacy) and in the `1.x` tags. There is no
+  automatic migration path: stop the Compose stack, re-upload the documents, then
+  decommission it once satisfied.
+
+---
+
+## [1.2.1] - 2026-05-27
+
+### Added
+
+- `.zenodo.json` with project metadata, keywords, ORCID-linked author and
+  licence, enabling automatic DOI generation via [Zenodo](https://zenodo.org/)
+  so the project is citable as a research output. ORCID iD:
+  [0009-0003-8613-3065](https://orcid.org/0009-0003-8613-3065).
+
+No functional changes from 1.2.0.
+
+---
+
+## [1.2.0] - 2026-03-02
+
+### Added
+
+- **Multi-GPU support** — NVIDIA (CUDA), AMD (ROCm) and CPU-only modes
+  ([#9](https://github.com/I3K-IT/RAG-Enterprise/issues/9))
+  - New `GPU_TYPE` setting in `.env` (`nvidia`, `amd`, `cpu`)
+  - Docker Compose override files: `docker-compose.nvidia.yml` (NVIDIA CUDA),
+    `docker-compose.amd.yml` (AMD ROCm)
+  - Setup wizard now asks GPU type and auto-configures the correct Docker images
+    and device mappings
+  - AMD uses the `ollama/ollama:rocm` image with `/dev/kfd` and `/dev/dri`
+    device passthrough
+  - CPU-only mode works out of the box with no GPU drivers required
+
+---
+
+## [1.1.5] - 2026-03-01
+
+### Added
+
+- **Automatic model download at startup** — if the configured LLM model is not
+  present in Ollama, the backend downloads it showing real-time progress:
+  percentage, downloaded/total size, speed and estimated time remaining
+- **Ollama readiness check** — the backend waits for Ollama to be reachable
+  before proceeding, preventing 404/connection errors on fresh installations
+
+### Fixed
+
+- **Ollama URL now configurable** via `OLLAMA_HOST` and `OLLAMA_PORT` environment
+  variables — previously hardcoded to `http://ollama:11434`, which only worked
+  inside Docker networking
+- Replaced stale `MILVIUS_HOST`/`MILVIUS_PORT` env vars in the Dockerfile with
+  correct `OLLAMA_HOST`/`OLLAMA_PORT` defaults
+
+---
+
+## [1.1.0] - 2026-02-27
+
+### Added
+
+- **Backup & Restore system** with full admin panel UI
+  - One-click local backup of database, documents and vector store
+  - Cloud backup via rclone (70+ providers: Mega, S3, Google Drive, OneDrive,
+    Dropbox, WebDAV, FTP, SFTP, B2, pCloud)
+  - Automatic scheduled backups with cron expressions and configurable retention
+    policies
+  - Selective restore (choose which components to restore individually)
+  - Cloud provider management with connection testing
+  - Backup history tracking (last 100 operations)
+  - Download backups from cloud to local storage
+- Complete backup documentation (`docs/BACKUP.md`) with setup guides for all
+  providers
+- rclone pre-installed in the Docker image for cloud storage integration
+
+### Security
+
+- All backup endpoints require admin role authentication
+- Cloud provider passwords encrypted via rclone obscure mechanism
+- Path traversal protection on archive extraction during restore
+- Safe online SQLite backup (no downtime, no data corruption)
+
+---
+
+## [1.0.0] - 2026-02-21
+
+First public release of RAG Enterprise — a 100% local Retrieval-Augmented
+Generation system for organisations that need complete data privacy.
+
+### Added
+
+- One-command setup with Docker Compose (`setup.sh`)
+- Multi-format document processing (PDF, DOCX, PPTX, XLSX, TXT, MD, ODT, RTF,
+  HTML, XML)
+- Local LLM inference via Ollama (Qwen3 14B Q4, Mistral 7B Q4)
+- Vector search with Qdrant and BAAI/bge-m3 multilingual embeddings
+- OCR pipeline for scanned documents (Tesseract + Apache Tika)
+- JWT authentication with role-based access control (user / super user / admin)
+- Conversational memory per user with session isolation
+- GPU acceleration support (NVIDIA CUDA)
+- 29-language support for document processing and retrieval
+- React + Vite frontend with Tailwind CSS
+- Auto-configuration of network and security during setup
+- Smart PDF detection and routing (digital vs scanned)
+- Benchmark script for performance testing
+- Community files: contributing guide, issue templates, PR template, roadmap
+- Qdrant API key support for secured deployments
+
+### Security
+
+- Production-ready JWT + CORS configuration
+- Conversation isolation between users
+- Removal of all hardcoded credentials
+- Automatic security configuration during setup
+
+### Performance
+
+- Direct Ollama API client replacing the LangChain wrapper
+- Optimised RAG search parameters for large documents
+- GPU memory management with automatic CPU fallback
+- Tika heap tuning (4 GB) with auto-restart on failure
+- Robust timeout and auto-recovery for document processing
+- Thread pool execution for document processing, to avoid blocking the event loop
+- OOM crash prevention on sequential document uploads
+
+### Fixed
+
+- PyTorch and CUDA compatibility across GPU generations
+- Embedding batch size tuning with CUDA fallback
+- HTTP enforcement for local Qdrant connections
+- Benchmark script authentication and output paths
+- PaddleOCR / PyMuPDF dependency conflict resolution
+
+### Changed
+
+- LLM switched from Qwen 2.5 to Qwen3 14B Q4\_K\_M for improved quality
+- All Italian text translated to English for international accessibility
+
+---
+
+[Unreleased]: https://github.com/I3K-IT/RAG-Enterprise/compare/v0.1.26...HEAD
+[0.1.26]: https://github.com/I3K-IT/RAG-Enterprise/compare/v0.1.25...v0.1.26
+[0.1.25]: https://github.com/I3K-IT/RAG-Enterprise/releases/tag/v0.1.25
+[1.2.1]: https://github.com/I3K-IT/RAG-Enterprise/releases/tag/v1.2.1
+[1.2.0]: https://github.com/I3K-IT/RAG-Enterprise/releases/tag/1.2.0
+[1.1.5]: https://github.com/I3K-IT/RAG-Enterprise/releases/tag/1.1.5
+[1.1.0]: https://github.com/I3K-IT/RAG-Enterprise/releases/tag/1.1.0
+[1.0.0]: https://github.com/I3K-IT/RAG-Enterprise/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# I3K RAG Engine
+# i3k RAG Engine
 
 **Ask questions about your own documents. Everything runs on your machine.**
 
@@ -11,13 +11,15 @@ questions in plain language, get answers grounded in what those documents
 actually say, with the sources cited. No data ever leaves your server — there
 is no telemetry, and nothing is sent to an external API.
 
-> **v2 is a complete rewrite in Rust.** v1 was a Python stack: four containers
-> under Docker Compose — backend, frontend, Qdrant, Ollama — two of them built
-> on your machine, plus seven volumes to keep straight. v2 is one binary. It
-> starts Qdrant and the inference engine itself; there is nothing to compose and
-> nothing to build.
+> **This is a complete rewrite in Rust.** The `1.x` releases were a Python
+> stack: four containers under Docker Compose — backend, frontend, Qdrant,
+> Ollama — two of them built on your machine, plus seven volumes to keep
+> straight. This is one binary. It starts Qdrant and the inference engine
+> itself; there is nothing to compose and nothing to build.
 >
-> The Python version is preserved on the
+> The rewrite restarts the numbering at `0.1`, so it is *lower*-numbered than
+> the `1.x` line it replaces: it is a new codebase whose storage layout and HTTP
+> surface are not settled yet. The Python version is preserved on the
 > [`python-legacy`](../../tree/python-legacy) branch and in the `1.x` tags — see
 > [Upgrading from 1.x](#upgrading-from-1x).
 
@@ -38,7 +40,8 @@ data-sovereignty reasons: law firms, healthcare, finance, public administration.
 
 ## Quick start
 
-Download the tarball for your platform from the [releases](../../releases) page:
+Download the tarball for your platform from the [releases](../../releases) page
+— [CHANGELOG.md](CHANGELOG.md) records what changed in each one:
 
 | File | For |
 |---|---|
@@ -156,15 +159,16 @@ query of a session and reports on shutdown.
 
 ## Upgrading from 1.x
 
-There is no automatic migration path, because v2 changes both the storage
-layout and the runtime model: v1 kept its state in Docker volumes shared
-between containers, v2 keeps it in one data directory next to the binary.
+There is no automatic migration path, because the rewrite changes both the
+storage layout and the runtime model: `1.x` kept its state in Docker volumes
+shared between containers, `0.1.x` keeps it in one data directory next to the
+binary.
 
 The two cannot run at the same time on one machine: they both want ports 8000,
-6333 and 11434. Stop the Compose stack before starting v2 — you are re-uploading
-anyway, so there is no moment where you need both. Your v1 data stays in its
-Docker volumes until you remove them, so you can go back by bringing Compose up
-again. Once you are satisfied, `docker compose down -v` retires it for good.
+6333 and 11434. Stop the Compose stack first — you are re-uploading anyway, so
+there is no moment where you need both. Your `1.x` data stays in its Docker
+volumes until you remove them, so you can go back by bringing Compose up again.
+Once you are satisfied, `docker compose down -v` retires it for good.
 
 The 1.x Python version remains available on the
 [`python-legacy`](../../tree/python-legacy) branch and in the `1.x` tags. It is


### PR DESCRIPTION
The Python stack had a CHANGELOG in Keep a Changelog format covering 1.0.0 to 1.2.0. It stayed behind on python-legacy when main became the Rust tree, so the project lost its release history at exactly the point it went public.

This restores it as one continuous file rather than starting a second one: the 1.x entries are carried over, 1.2.1 is added (it was released but never recorded), and 0.1.25 and 0.1.26 are written up on top. An Unreleased section at the head is where entries accumulate between releases, and the README points at the file from the Quick start.

Fixed the link anchors inherited from the old file: 1.0.0, 1.1.0 and 1.1.5 were linked with a "v" prefix their tags do not have, so all three were dead.

Also drops the "v1" and "v2" labels the README had started using. Those versions do not exist: the Python line shipped 1.0.0 to 1.2.1 and this one ships 0.1.25 and 0.1.26, so "v2 is a complete rewrite" sat next to a v0.1.26 badge and sent the reader looking for a 2.x release. It also implied the newer line is the higher number when it is deliberately the lower one. Both files now say "the 1.x releases" and "this rewrite", and a note in the CHANGELOG explains the inversion once, where it belongs.