### PR TITLE
feat: make repeat_last_n configurable, add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,157 @@
+# i3k-rag-engine — configuration template.
+#
+# Copy this file to `.env` next to the binary (or in the CWD you run it
+# from) and fill in / uncomment what you need. Everything below has a
+# working default baked into the binary — this file only needs the values
+# you actually want to CHANGE; delete or leave commented-out the rest.
+#
+# Loading order (config::Settings::load, src/config.rs):
+#   1. `.env` in the current working directory (dev: `cargo run` from repo root)
+#   2. `.env` next to the executable (production: the install directory)
+#   3. real process environment variables (always win over both files above)
+#
+# Naming: SECTION__FIELD, uppercase, double underscore as the nesting
+# separator (the `config` crate's Environment::separator("__")) — e.g. the
+# `eullm.repeat_penalty` field is EULLM__REPEAT_PENALTY.
+#
+# Everything here is safe to change at runtime (just restart the binary —
+# no rebuild needed) UNLESS explicitly noted otherwise.
+
+
+# ── Server ───────────────────────────────────────────────────────────────────
+# SERVER__HOST=0.0.0.0
+# SERVER__PORT=8000
+
+
+# ── Database (SQLite: users, conversations, backup metadata) ───────────────────
+# Default is derived from DATA__DIR (see below): {data}/db/rag_users.db.
+# Only set this to move the DB somewhere DATA__DIR doesn't already cover.
+# DATABASE__URL=sqlite:///path/to/rag_users.db
+
+
+# ── Auth ─────────────────────────────────────────────────────────────────────
+# REQUIRED — no default, startup fails without it. Use a long random string
+# (e.g. `openssl rand -hex 32`).
+AUTH__JWT_SECRET=change-this-to-a-long-random-string
+
+# AUTH__JWT_EXPIRY_MINUTES=480
+# AUTH__ADMIN_DEFAULT_PASSWORD=
+
+
+# ── Qdrant ───────────────────────────────────────────────────────────────────
+# QDRANT__URL=http://localhost:6333          # REST — bootstrap healthcheck
+# QDRANT__GRPC_URL=http://localhost:6334     # gRPC — actual vector queries
+# QDRANT__COLLECTION=rag_documents           # fixed at 1024 dims (bge-m3) — see EMBEDDINGS__MODEL_ID below
+
+
+# ── eullm (LLM inference engine) ────────────────────────────────────────────
+# EULLM__URL=http://localhost:11434
+
+# Only used when DATA__MANAGE_SUBPROCESSES=false (eullm run externally, not
+# spawned by this binary): must be a direct GGUF path or a name already
+# imported via `eullm import-ollama`. Ignored (harmlessly) when this binary
+# starts eullm itself, the default — it uses the manifest-pinned model then.
+# EULLM__MODEL=qwen3-14b
+
+# Context PER CONNECTION SLOT (not the total passed to eullm at startup,
+# which is num_ctx * batch_size — see bootstrap::spawn_eullm).
+# EULLM__NUM_CTX=16384
+
+# Max tokens generated per answer.
+# EULLM__NUM_PREDICT=4096
+
+# How strongly recently-used tokens are penalized against repeating.
+# Default 1.3. Ollama's own default (used by the old python-legacy stack,
+# which never overrode it) is 1.1 — noticeably lighter. If generations look
+# repetitive, garbled, or oddly worded, try lowering this toward 1.1 first.
+# EULLM__REPEAT_PENALTY=1.3
+
+# How many recent tokens repeat_penalty actually looks back over. Default
+# 256 — until this release this was hardcoded with NO way to override it.
+# Ollama's default (python-legacy) is 64: a much shorter window. A high
+# penalty (1.3) over a long window (256) is a materially more aggressive
+# anti-repetition setting than what the old stack ever ran with — the
+# combination most likely to explain answers that read as "strange"
+# compared to python-legacy. Try 64 to match python-legacy's real behavior.
+# EULLM__REPEAT_LAST_N=256
+
+# -1 = keep the model loaded indefinitely once warm. 0 = unload immediately
+# after each request. A positive number is seconds.
+# EULLM__KEEP_ALIVE=-1
+
+# Concurrent connections/slots. KV-cache VRAM scales as num_ctx * batch_size
+# — check the VRAM budget (BUILD.md) before raising this.
+# EULLM__BATCH_SIZE=1
+
+# KV-cache quantization (llama.cpp: f16 | q8_0 | q4_0…). Unset = eullm's own
+# default (F16). NOT confirmed honored on every GPU — check eullm's own logs
+# after setting it, do not assume.
+# EULLM__CACHE_TYPE_K=
+# EULLM__CACHE_TYPE_V=
+
+# Evict eullm from VRAM for the duration of document ingestion. While this
+# is active, chat is unavailable (the UI shows "ingestion in progress").
+# EULLM__UNLOAD_DURING_INGESTION=false
+
+# Bypasses the manifest-pinned chat model and passes this straight to
+# `eullm run` instead — a local GGUF path, or an hf.co/user/repo:quant
+# reference eullm resolves and downloads itself, OUTSIDE this project's
+# sha256-pinned manifest (integrity becomes eullm's/HF's responsibility,
+# not ours). Only takes effect when DATA__MANAGE_SUBPROCESSES=true.
+# EULLM__MODEL_OVERRIDE=
+
+# Expert layers kept in CPU RAM (--n-cpu-moe). Leave unset — eullm sizes
+# this itself from the GGUF's real tensor sizes. Setting it DISABLES that
+# auto-sizing and is almost always worse. See the doc comment on
+# EullmSettings::n_cpu_moe in src/config.rs before touching this.
+# EULLM__N_CPU_MOE=
+
+# Only consulted when EMBEDDINGS__INGESTION_EMBEDDING=eullm. true = reserve
+# permanent VRAM for bge-m3 alongside the chat model at eullm startup (only
+# safe on a card that comfortably fits both — otherwise it starves the chat
+# model). false (default) = eullm decides per-call whether bge-m3 fits or
+# must evict the chat model temporarily. See the doc comment on
+# EullmSettings::reserve_embedding_model in src/config.rs before enabling.
+# EULLM__RESERVE_EMBEDDING_MODEL=false
+
+
+# ── Embeddings ───────────────────────────────────────────────────────────────
+# Which weights actually load for the in-process (Candle) embedding path.
+# Changing this away from BAAI/bge-m3 also requires QDRANT__COLLECTION to
+# point at a collection created with the new model's own vector size — the
+# current collection is hardcoded to 1024 dims (bge-m3's) in
+# src/clients/qdrant_store.rs. Do not change one without the other.
+# EMBEDDINGS__MODEL_ID=BAAI/bge-m3
+
+# true = CUDA is mandatory; startup fails outright rather than silently
+# degrading to a much slower CPU load. false = CPU fallback allowed (logged
+# at error level, exposed via GET /info either way).
+# EMBEDDINGS__REQUIRE_GPU=false
+
+# How document-ingestion embedding is generated: off (Candle, no device
+# change — default) | candle_gpu (Candle, CPU<->GPU swap just for
+# ingestion, needs EULLM__UNLOAD_DURING_INGESTION=true and a binary built
+# with --features cuda) | eullm (routed through eullm's own POST
+# /api/embed, needs eullm >= 0.6.82, no --features cuda required). See the
+# IngestionEmbedding doc comment in src/config.rs — the three modes are NOT
+# interchangeable, picking the wrong one for your hardware is worse than
+# picking none.
+# EMBEDDINGS__INGESTION_EMBEDDING=off
+
+
+# ── Storage / backup / data root ─────────────────────────────────────────────
+# Root for binaries, models, Qdrant storage, the SQLite DB, and uploads:
+# {dir}/bin  {dir}/models  {dir}/storage  {dir}/db  {dir}/uploads
+# Default: the directory holding the executable (portable-app layout). In
+# dev (`cargo run`, binary under target/debug/) you almost always want to
+# override this, e.g.:
+# DATA__DIR=./data
+
+# false = expect qdrant/eullm to already be listening (dev with `docker
+# compose`, or externally managed) instead of spawning/supervising them as
+# child processes.
+# DATA__MANAGE_SUBPROCESSES=true
+
+# STORAGE__DOCUMENTS_DIR=            # default: {DATA__DIR}/uploads
+# STORAGE__MAX_UPLOAD_MB=100
+# BACKUP__DIR=                       # default: {DATA__DIR}/backups

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target/
 .env
 .env.*
+!.env.example
 *.db
 *.db-shm
 *.db-wal

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -128,6 +128,7 @@ mod eullm_args_tests {
             num_ctx: 16384,
             num_predict: 4096,
             repeat_penalty: 1.3,
+            repeat_last_n: 256,
             keep_alive: -1,
             batch_size: 1,
             cache_type_k: None,

--- a/src/clients/eullm.rs
+++ b/src/clients/eullm.rs
@@ -6,7 +6,7 @@
 //! - keep_alive: -1 (top-level, not in options)
 //! - Prompt: ChatML wrap + <think>\n</think>\n prefill  (strips any residual
 //!   ChatML special tokens from the user text before wrapping).
-//! - options: temperature 0.0, num_ctx, num_predict, repeat_penalty, repeat_last_n 256
+//! - options: temperature 0.0, num_ctx, num_predict, repeat_penalty, repeat_last_n
 //! - NO "stop" field anywhere in the payload.
 //! - Strip <think>...</think> blocks from non-streaming response.
 
@@ -102,6 +102,7 @@ pub struct EullmClient {
     num_ctx: u32,
     num_predict: u32,
     repeat_penalty: f32,
+    repeat_last_n: u32,
     keep_alive: i32,
 }
 
@@ -112,13 +113,14 @@ impl EullmClient {
         num_ctx: u32,
         num_predict: u32,
         repeat_penalty: f32,
+        repeat_last_n: u32,
         keep_alive: i32,
     ) -> Self {
         let http = Client::builder()
             .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
             .build()
             .expect("reqwest Client build");
-        Self { http, base_url, model, num_ctx, num_predict, repeat_penalty, keep_alive }
+        Self { http, base_url, model, num_ctx, num_predict, repeat_penalty, repeat_last_n, keep_alive }
     }
 
     fn build_prompt(&self, user_text: &str) -> String {
@@ -133,7 +135,7 @@ impl EullmClient {
             num_ctx: self.num_ctx,
             num_predict: self.num_predict,
             repeat_penalty: self.repeat_penalty,
-            repeat_last_n: 256,
+            repeat_last_n: self.repeat_last_n,
         }
     }
 
@@ -379,7 +381,7 @@ mod tests {
         EullmClient::new(
             "http://localhost:11434".into(),
             "qwen3:14b".into(),
-            16384, 4096, 1.3, -1,
+            16384, 4096, 1.3, 256, -1,
         )
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,6 +80,15 @@ pub struct EullmSettings {
     pub num_predict: u32,
     #[serde(default = "default_repeat_penalty")]
     pub repeat_penalty: f32,
+    /// How many recent tokens repeat_penalty looks back over (llama.cpp
+    /// `repeat_last_n`). Was hardcoded to 256 with no way to override it —
+    /// Ollama's own default is 64 (repeat_penalty 1.1, vs our 1.3): a
+    /// smaller window and a lighter penalty. Default here stays 256 to keep
+    /// existing deployments byte-for-byte unchanged; lower it (e.g. 64) to
+    /// match Ollama's proven-working combination if generation quality
+    /// regresses relative to the python-legacy stack.
+    #[serde(default = "default_repeat_last_n")]
+    pub repeat_last_n: u32,
     #[serde(default = "default_keep_alive")]
     pub keep_alive: i32,
     /// Concurrent connections handled by eullm. KV cache VRAM scales linearly
@@ -340,6 +349,7 @@ fn default_num_ctx() -> u32 { 16384 }
 fn default_eullm_batch_size() -> u32 { 1 }
 fn default_num_predict() -> u32 { 4096 }
 fn default_repeat_penalty() -> f32 { 1.3 }
+fn default_repeat_last_n() -> u32 { 256 }
 fn default_keep_alive() -> i32 { -1 }
 fn default_embedding_model() -> String { "BAAI/bge-m3".into() }
 fn default_backup_dir() -> String { "./backups".into() }

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,6 +273,7 @@ async fn build_eullm_client(
         settings.eullm.num_ctx,
         settings.eullm.num_predict,
         settings.eullm.repeat_penalty,
+        settings.eullm.repeat_last_n,
         settings.eullm.keep_alive,
     )
 }


### PR DESCRIPTION
EullmSettings.repeat_last_n (new, EULLM__REPEAT_LAST_N, default 256 — no behavior change) replaces a value that was hardcoded in clients/eullm.rs with no way to override it short of a rebuild.

Prompted by comparing this pipeline against python-legacy's: the old stack never overrode Ollama's defaults (repeat_penalty 1.1, repeat_last_n 64), while this one hardcodes repeat_penalty 1.3 over a 256-token window — a meaningfully more aggressive anti-repetition setting. Exposing repeat_last_n means both knobs can now be tuned from .env without a rebuild, in case that combination is contributing to the "strange" generations reported.

Also adds .env.example, documenting every SECTION__FIELD env var Settings::load() reads (src/config.rs), with the eullm generation knobs called out specifically since they're the ones most likely to need hand-tuning per deployment. .gitignore's `.env.*` pattern was swallowing it silently — added `!.env.example` to keep the template tracked while real .env files stay ignored.