### PR TITLE
chore: version 0.1.32 — fix Settings::load(), configurable repeat_last_n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.1.32] - 2026-08-20
+
+### Fixed
+
+- **`Settings::load()` rejected the minimal `.env` README.md has
+  documented since 0.1.28.** Every field of `EullmSettings` already
+  had its own default, but the `Settings.eullm` field itself had no
+  `#[serde(default)]` and `EullmSettings` had no `Default` impl — with
+  zero `EULLM__*` variables set, config loading failed outright with
+  "missing field `eullm`" before ever reaching the individual fields'
+  defaults. Verified against the actual compiled binary, not just the
+  struct definitions: running it with only `AUTH__JWT_SECRET` set
+  reproduced the failure before the fix, and reached the real
+  bootstrap/download flow after it. Every other documented `.env`
+  example (`BUILD.md`) happened to already set `EULLM__URL`/
+  `EULLM__MODEL` explicitly, which is why this went unnoticed.
+
+### Added
+
+- `EULLM__REPEAT_LAST_N` — how many recent tokens `repeat_penalty`
+  looks back over, previously hardcoded to 256 with no way to change
+  it short of a rebuild. Default unchanged (256).
+- `.env.example` at the repo root, documenting every `SECTION__FIELD`
+  variable `Settings::load()` reads.
+
 ## [0.1.31] - 2026-08-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i3k-rag-engine"
-version = "0.1.31"
+version = "0.1.32"
 edition = "2021"
 description = "i3k RAG Engine — self-hosted document intelligence, fully local"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ eullm 0.6.82, for embedding too when asked (see [Architecture](#architecture)).
 No separate GPU build or download is needed on any platform.
 
 ```sh
-tar -xzf i3k-rag-engine-v0.1.31-linux-x86_64.tar.gz
-cd i3k-rag-engine-v0.1.31-linux-x86_64
+tar -xzf i3k-rag-engine-v0.1.32-linux-x86_64.tar.gz
+cd i3k-rag-engine-v0.1.32-linux-x86_64
 
 cat > .env <<'EOF'
 AUTH__JWT_SECRET=change-this-to-a-long-random-string

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,8 @@ pub struct Settings {
     pub auth: AuthSettings,          // jwt_secret required — no default
     #[serde(default)]
     pub qdrant: QdrantSettings,
-    pub eullm: EullmSettings,        // model required — no default
+    #[serde(default)]
+    pub eullm: EullmSettings,
     #[serde(default)]
     pub embeddings: EmbeddingsSettings,
     #[serde(default)]
@@ -303,6 +304,26 @@ impl Default for ServerSettings {
 }
 impl Default for DatabaseSettings {
     fn default() -> Self { Self { url: default_db_url() } }
+}
+impl Default for EullmSettings {
+    fn default() -> Self {
+        Self {
+            url: default_eullm_url(),
+            model: default_eullm_model(),
+            num_ctx: default_num_ctx(),
+            num_predict: default_num_predict(),
+            repeat_penalty: default_repeat_penalty(),
+            repeat_last_n: default_repeat_last_n(),
+            keep_alive: default_keep_alive(),
+            batch_size: default_eullm_batch_size(),
+            cache_type_k: None,
+            cache_type_v: None,
+            unload_during_ingestion: false,
+            model_override: None,
+            n_cpu_moe: None,
+            reserve_embedding_model: false,
+        }
+    }
 }
 impl Default for QdrantSettings {
     fn default() -> Self {


### PR DESCRIPTION
## Summary
- Fix: `Settings.eullm` had no `#[serde(default)]` and `EullmSettings` had no `Default` impl, so `Settings::load()` rejected the minimal `.env` README.md has documented since 0.1.28 ("missing field `eullm`" with zero `EULLM__*` vars set). Verified against the compiled binary, not just the struct definitions.
- Add `EULLM__REPEAT_LAST_N` (default 256, unchanged) — was hardcoded with no way to override it.
- Add `.env.example` documenting every `SECTION__FIELD` variable `Settings::load()` reads.
- Version bump to 0.1.32, CHANGELOG entry, README tarball references updated.

## Test plan
- [x] `cargo test` — 101/101 passing
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Ran the compiled release binary with only `AUTH__JWT_SECRET` set: failed with "missing field `eullm`" before the fix, reached the real bootstrap/download flow after it


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTxeALuXYxrGVnkD722xJE)_