### PR TITLE
chore: update Cargo.lock for 0.1.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "i3k-rag-engine"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "argon2",


### PR DESCRIPTION
Cargo.lock's own version entry for this package was still 0.1.31, missed in the version-bump commit that landed in #28.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HTxeALuXYxrGVnkD722xJE)_