### PR TITLE
security: bind qdrant to loopback; ship .env.example in release tarballs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,7 @@ jobs:
         run: |
           mkdir -p dist stage/frontend
           cp target/release/i3k-rag-engine stage/
+          cp .env.example stage/
           cp -r frontend/dist stage/frontend/dist
           # Versione nel nome del tarball: GITHUB_REF su un tag è
           # "refs/tags/v0.1.3" — questo job gira solo su tag (if: sopra),
@@ -472,6 +473,7 @@ jobs:
         run: |
           mkdir -p dist stage/frontend
           cp target/release/i3k-rag-engine stage/
+          cp .env.example stage/
           cp -r frontend/dist stage/frontend/dist
           VERSION="${GITHUB_REF#refs/tags/}"
           tar czf "dist/i3k-rag-engine-${VERSION}-linux-arm64.tar.gz" -C stage .
@@ -624,6 +626,7 @@ jobs:
           mkdir -p dist stage/frontend
           cp target/x86_64-pc-windows-gnu/release/i3k-rag-engine.exe stage/
           cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libstdc++-6.dll stage/
+          cp .env.example stage/
           cp -r frontend/dist stage/frontend/dist
           VERSION="${GITHUB_REF#refs/tags/}"
           (cd stage && zip -r "../dist/i3k-rag-engine-${VERSION}-windows-x86_64.zip" .)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.1.33] - 2026-08-20
 
+### Security
+
+- **Qdrant no longer listens on all network interfaces.** The bundled
+  qdrant binary defaults to `0.0.0.0` when its host isn't set —
+  verified by running the actual pinned binary and reading its own
+  startup log — and this project has no API key concept for it at
+  all, so on any host where ports 6333/6334 weren't independently
+  firewalled, the full REST+gRPC API (read, write, and delete every
+  ingested document, completely unauthenticated) was reachable by
+  anyone who could reach those ports, bypassing this binary's own JWT
+  auth entirely. Now bound to `127.0.0.1` explicitly — this binary
+  only ever talks to qdrant over localhost anyway, so nothing
+  functional changes. Deployments with `DATA__MANAGE_SUBPROCESSES=false`
+  (qdrant run externally) are unaffected either way — that qdrant's
+  bind address was never this project's to control.
+  eullm was checked too and needs no equivalent fix: it also listens
+  on `0.0.0.0` at the socket level, but enforces its own IP allowlist
+  at the application layer, loopback-only by default (`Allowed source
+  IPs/subnets: 127.0.0.1/32, ::1/128`, per its own startup log) — a
+  deliberate default, not an oversight.
+
+### Fixed
+
+- **Release tarballs did not include `.env.example`.** It existed in
+  the repository since 0.1.32 but the packaging step never copied it
+  into `stage/` alongside the binary, so anyone who downloaded a
+  release instead of cloning the repo had no configuration template
+  at all. Added to all three platform tarballs.
+
 ### Changed
 
 - **`EMBEDDINGS__INGESTION_EMBEDDING=eullm` now also covers query-time

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1802,11 +1802,21 @@ async fn kill_stale_process(bin: &Path) {
     tokio::time::sleep(Duration::from_millis(800)).await;
 }
 
+/// Bound to loopback only, not qdrant's own default (0.0.0.0 — verified by
+/// running the real pinned binary and reading its own startup log:
+/// "actix-web-service-0.0.0.0:6333"). There is no API key anywhere in this
+/// project's Qdrant integration (QdrantSettings has no such field), and
+/// QdrantSettings::default_qdrant_url/_grpc_url already point at localhost —
+/// this binary never has a reason to reach qdrant any other way, so loopback
+/// costs nothing functionally and closes an unauthenticated REST+gRPC vector
+/// database (every ingested document's full text, readable AND writable) off
+/// the network by default.
 fn spawn_qdrant(bin: &Path, storage: &Path) -> Result<tokio::process::Child> {
     Command::new(bin)
         .env("QDRANT__STORAGE__STORAGE_PATH", storage)
         .env("QDRANT__SERVICE__HTTP_PORT", "6333")
         .env("QDRANT__SERVICE__GRPC_PORT", "6334")
+        .env("QDRANT__SERVICE__HOST", "127.0.0.1")
         .kill_on_drop(true)
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::inherit())


### PR DESCRIPTION
qdrant defaults to 0.0.0.0 when QDRANT__SERVICE__HOST isn't set — confirmed by running the real pinned binary and reading its own startup log, not assumed. This project has no API key for it at all (QdrantSettings has no such field), so on any host where 6333/6334 weren't independently firewalled, the full REST+gRPC API — every ingested document, readable and writable — was reachable by anyone, completely bypassing this binary's own JWT auth. Bound to 127.0.0.1 explicitly in spawn_qdrant(): this process only ever talks to qdrant over localhost anyway (see default_qdrant_url/_grpc_url), so nothing functional changes.

Checked eullm for the same issue: also 0.0.0.0 at the socket level, but it enforces its own loopback-only IP allowlist at the application layer by default (verified via its own startup log) — a deliberate design, not a gap, no fix needed there.

Separately: .env.example existed in the repo since 0.1.32 but the release packaging step never copied it into any of the three platform tarballs, so anyone who downloaded a release instead of cloning the repo had no configuration template at all. Added to all three.